### PR TITLE
Fix hero command count

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function Home() {
               <Text mb='md'>
                 With over{' '}
                 <Link href='/commands' className='link hover:underline'>
-                  130 commands
+                  160 commands
                 </Link>
                 , EssentialsX provides one of the most comprehensive feature
                 sets out there, providing teleportation, moderation tools,


### PR DESCRIPTION
## Summary
- adjust hero section copy to reference over 160 commands

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_683f529a8ba48324bac0a1cfcac2571f