### PR TITLE
Add command filtering and anchors

### DIFF
--- a/app/commands/page.tsx
+++ b/app/commands/page.tsx
@@ -22,13 +22,14 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Fragment, useEffect, useState } from 'react';
 import { Entries } from 'type-fest';
 
-function sortAliases(aliases: string[]): string[] {
-  const set = new Set(aliases);
+function sortAliases(command: string, aliases: string[]): string[] {
+  const set = new Set([...aliases, command]);
   return [...aliases].sort((a, b) => {
     const aIsE = a.startsWith('e') && set.has(a.slice(1));
     const bIsE = b.startsWith('e') && set.has(b.slice(1));
-    if (aIsE === bIsE) return a.localeCompare(b);
-    return aIsE ? 1 : -1;
+    if (aIsE !== bIsE) return aIsE ? 1 : -1;
+    if (a.length !== b.length) return a.length - b.length;
+    return a.localeCompare(b);
   });
 }
 
@@ -69,6 +70,19 @@ export default function Commands() {
 
   const [search, setSearch] = useState('');
   const [moduleFilter, setModuleFilter] = useState<string | null>(null);
+
+  // Scroll to anchor once commands are loaded
+  useEffect(() => {
+    if (!loading && typeof window !== 'undefined') {
+      const id = window.location.hash.slice(1);
+      if (id) {
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth' });
+        }
+      }
+    }
+  }, [loading]);
 
   if (loading) {
     return (
@@ -139,7 +153,7 @@ export default function Commands() {
                         ),
                     )
                     .map(([cmd, obj]: [string, Command]) => {
-                      const sortedAliases = sortAliases(obj.aliases);
+                      const sortedAliases = sortAliases(cmd, obj.aliases);
                       return (
                         <Fragment key={cmd}>
                           <div

--- a/app/commands/page.tsx
+++ b/app/commands/page.tsx
@@ -11,11 +11,26 @@ import discordlink from '@/lib/EssentialsXDiscordLink-commands.json';
 import spawn from '@/lib/EssentialsXSpawn-commands.json';
 import xmpp from '@/lib/EssentialsXXMPP-commands.json';
 import { Command, CommandData } from '@/lib/types';
-import { Badge, Button } from '@mantine/core';
-import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { Badge, Button, Select, TextInput } from '@mantine/core';
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconHash,
+  IconSearch,
+} from '@tabler/icons-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Fragment, useEffect, useState } from 'react';
 import { Entries } from 'type-fest';
+
+function sortAliases(aliases: string[]): string[] {
+  const set = new Set(aliases);
+  return [...aliases].sort((a, b) => {
+    const aIsE = a.startsWith('e') && set.has(a.slice(1));
+    const bIsE = b.startsWith('e') && set.has(b.slice(1));
+    if (aIsE === bIsE) return a.localeCompare(b);
+    return aIsE ? 1 : -1;
+  });
+}
 
 export default function Commands() {
   const [allCommands, setAllCommands] = useState<Record<string, CommandData>>(
@@ -52,6 +67,9 @@ export default function Commands() {
     setOpenRow(prev => (prev === cmd ? '' : cmd));
   };
 
+  const [search, setSearch] = useState('');
+  const [moduleFilter, setModuleFilter] = useState<string | null>(null);
+
   if (loading) {
     return (
       <div className='flex flex-col min-h-screen'>
@@ -83,7 +101,24 @@ export default function Commands() {
       <div className='flex-1 container mx-auto px-4 py-8'>
         <div className='bg-background rounded-lg border shadow-sm overflow-hidden'>
           <div className='w-full'>
-            <div className='grid grid-cols-5 gap-4 p-4 border-b font-semibold text-sm'>
+            <div className='flex gap-4 p-4 border-b border-gray-300 dark:border-gray-700'>
+              <TextInput
+                placeholder='Search commands'
+                leftSection={<IconSearch size={16} />}
+                value={search}
+                onChange={e => setSearch(e.currentTarget.value)}
+                style={{ flex: 1 }}
+              />
+              <Select
+                placeholder='Filter module'
+                data={['All', ...Object.keys(allCommands)]}
+                value={moduleFilter || 'All'}
+                onChange={value =>
+                  setModuleFilter(value === 'All' ? null : value)
+                }
+              />
+            </div>
+            <div className='grid grid-cols-5 gap-4 p-4 border-b border-gray-300 dark:border-gray-700 font-semibold text-sm'>
               <div>Module</div>
               <div>Command</div>
               <div>Aliases</div>
@@ -93,106 +128,129 @@ export default function Commands() {
 
             <div>
               {Object.entries(allCommands).map(([mod, cmds]) =>
-                (Object.entries(cmds) as Entries<Record<string, Command>>).map(
-                  ([cmd, obj]: [string, Command]) => (
-                    <Fragment key={cmd}>
-                      <div className='border-b'>
-                        <div className='grid grid-cols-5 gap-4 p-4 items-center'>
-                          <div className='flex items-center'>
-                            <Badge variant='secondary' className='text-xs'>
-                              {mod}
-                            </Badge>
-                          </div>
+                moduleFilter && moduleFilter !== mod ?
+                  null
+                : (Object.entries(cmds) as Entries<Record<string, Command>>)
+                    .filter(
+                      ([command, obj]) =>
+                        command.toLowerCase().includes(search.toLowerCase()) ||
+                        obj.aliases.some(a =>
+                          a.toLowerCase().includes(search.toLowerCase()),
+                        ),
+                    )
+                    .map(([cmd, obj]: [string, Command]) => {
+                      const sortedAliases = sortAliases(obj.aliases);
+                      return (
+                        <Fragment key={cmd}>
+                          <div
+                            className='border-b border-gray-200 dark:border-gray-700'
+                            id={cmd}
+                          >
+                            <div className='grid grid-cols-5 gap-4 p-4 items-center'>
+                              <div className='flex items-center'>
+                                <Badge variant='secondary' className='text-xs'>
+                                  {mod}
+                                </Badge>
+                              </div>
 
-                          <div className='flex items-center text-sm prose dark:prose-invert'>
-                            <code className='px-2 py-1 rounded text-xs'>
-                              /{cmd}
-                            </code>
-                          </div>
-
-                          <div className='prose dark:prose-invert'>
-                            {obj.aliases.length === 0 ?
-                              <span className='text-sm'>None</span>
-                            : obj.aliases.length === 1 ?
-                              <code className='text-xs px-1 py-0.5 rounded'>
-                                {obj.aliases[0]}
-                              </code>
-                            : <div className='gap-1'>
-                                <code className='text-xs px-1 py-0.5 rounded'>
-                                  {obj.aliases[0]}
-                                </code>
-                                <Button
-                                  variant='transparent'
-                                  size='sm'
-                                  px={4}
-                                  className='!cursor-default'
+                              <div className='flex items-center text-sm prose dark:prose-invert'>
+                                <a
+                                  href={`#${cmd}`}
+                                  className='flex items-center gap-1'
                                 >
-                                  <IconChevronRight className='h-4 w-4' />
-                                </Button>
-                                {obj.aliases.length > 1 && (
-                                  <span className='text-xs text-muted-foreground'>
-                                    +{obj.aliases.length - 1} more
-                                  </span>
+                                  <code className='px-2 py-1 rounded text-xs'>
+                                    /{cmd}
+                                  </code>
+                                  <IconHash
+                                    size={14}
+                                    className='text-muted-foreground'
+                                  />
+                                </a>
+                              </div>
+
+                              <div className='prose dark:prose-invert'>
+                                {sortedAliases.length === 0 ?
+                                  <span className='text-sm'>None</span>
+                                : sortedAliases.length === 1 ?
+                                  <code className='text-xs px-1 py-0.5 rounded'>
+                                    {sortedAliases[0]}
+                                  </code>
+                                : <div className='gap-1'>
+                                    <code className='text-xs px-1 py-0.5 rounded'>
+                                      {sortedAliases[0]}
+                                    </code>
+                                    <Button
+                                      variant='transparent'
+                                      size='sm'
+                                      px={4}
+                                      className='!cursor-default'
+                                    >
+                                      <IconChevronRight className='h-4 w-4' />
+                                    </Button>
+                                    {sortedAliases.length > 1 && (
+                                      <span className='text-xs text-muted-foreground'>
+                                        +{sortedAliases.length - 1} more
+                                      </span>
+                                    )}
+                                  </div>
+                                }
+                              </div>
+
+                              <div className='text-sm flex items-center'>
+                                {obj.description || 'None'}
+                              </div>
+
+                              <div className='flex items-center gap-2 prose dark:prose-invert'>
+                                <code className='px-2 py-1 rounded text-xs flex-1 truncate'>
+                                  /{cmd}
+                                  {obj.usage ? obj.usage.slice(10) : ''}
+                                </code>
+                                {(obj.usages?.length > 0 ||
+                                  sortedAliases.length > 1) && (
+                                  <Button
+                                    variant='subtle'
+                                    size='xs'
+                                    px={4}
+                                    className='flex-shrink-0 transition-all duration-200 hover:scale-105'
+                                    onClick={() => toggleRow(cmd)}
+                                  >
+                                    <motion.div
+                                      animate={{
+                                        rotate: openRow === cmd ? 180 : 0,
+                                      }}
+                                      transition={{
+                                        duration: 0.2,
+                                        ease: 'easeInOut',
+                                      }}
+                                    >
+                                      <IconChevronDown className='h-4 w-4' />
+                                    </motion.div>
+                                  </Button>
                                 )}
                               </div>
-                            }
-                          </div>
+                            </div>
 
-                          <div className='text-sm flex items-center'>
-                            {obj.description || 'None'}
-                          </div>
+                            <AnimatePresence>
+                              {openRow === cmd && (
+                                <motion.div className='flex flex-row gap-0 justify-end items-center'>
+                                  {sortedAliases.length > 1 && (
+                                    <div>
+                                      <CommandAliases aliases={sortedAliases} />
+                                    </div>
+                                  )}
 
-                          <div className='flex items-center gap-2 prose dark:prose-invert'>
-                            <code className='px-2 py-1 rounded text-xs flex-1 truncate'>
-                              /{cmd}
-                              {obj.usage ? obj.usage.slice(10) : ''}
-                            </code>
-                            {(obj.usages?.length > 0 ||
-                              obj.aliases?.length > 1) && (
-                              <Button
-                                variant='subtle'
-                                size='xs'
-                                px={4}
-                                className='flex-shrink-0 transition-all duration-200 hover:scale-105'
-                                onClick={() => toggleRow(cmd)}
-                              >
-                                <motion.div
-                                  animate={{
-                                    rotate: openRow === cmd ? 180 : 0,
-                                  }}
-                                  transition={{
-                                    duration: 0.2,
-                                    ease: 'easeInOut',
-                                  }}
-                                >
-                                  <IconChevronDown className='h-4 w-4' />
+                                  {obj.usages?.length > 0 && (
+                                    <div>
+                                      <CommandUsages usages={obj.usages} />
+                                    </div>
+                                  )}
                                 </motion.div>
-                              </Button>
-                            )}
+                              )}
+                            </AnimatePresence>
                           </div>
-                        </div>
-
-                        <AnimatePresence>
-                          {openRow === cmd && (
-                            <motion.div className='flex flex-row gap-0 justify-end items-center'>
-                              {obj.aliases?.length > 1 && (
-                                <div>
-                                  <CommandAliases aliases={obj.aliases} />
-                                </div>
-                              )}
-
-                              {obj.usages?.length > 0 && (
-                                <div>
-                                  <CommandUsages usages={obj.usages} />
-                                </div>
-                              )}
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
-                      </div>
-                    </Fragment>
-                  ),
-                ),
+                        </Fragment>
+                      );
+                    }),
               )}
             </div>
           </div>

--- a/app/commands/page.tsx
+++ b/app/commands/page.tsx
@@ -78,7 +78,10 @@ export default function Commands() {
       if (id) {
         const el = document.getElementById(id);
         if (el) {
-          el.scrollIntoView({ behavior: 'smooth' });
+          const headerOffset = 80;
+          const y =
+            el.getBoundingClientRect().top + window.scrollY - headerOffset;
+          window.scrollTo({ top: y, behavior: 'smooth' });
         }
       }
     }
@@ -159,6 +162,7 @@ export default function Commands() {
                           <div
                             className='border-b border-gray-200 dark:border-gray-700'
                             id={cmd}
+                            style={{ scrollMarginTop: '80px' }}
                           >
                             <div className='grid grid-cols-5 gap-4 p-4 items-center'>
                               <div className='flex items-center'>

--- a/lib/__tests__/build-utils.test.ts
+++ b/lib/__tests__/build-utils.test.ts
@@ -1,30 +1,38 @@
-import { getVersionFromArtifact, getModuleIdFromArtifact, getCommitIdFromArtifact } from '../build-utils';
+import {
+  getCommitIdFromArtifact,
+  getModuleIdFromArtifact,
+  getVersionFromArtifact,
+} from '../build-utils';
 
 describe('build-utils', () => {
   test('getVersionFromArtifact returns correct version', () => {
     expect(getVersionFromArtifact('EssentialsX-2.20.1.jar')).toBe('2.20.1');
     expect(
-      getVersionFromArtifact('EssentialsX-2.20.1-dev+123-abcdef.jar')
+      getVersionFromArtifact('EssentialsX-2.20.1-dev+123-abcdef.jar'),
     ).toBe('2.20.1-dev+123-abcdef');
-    expect(
-      getVersionFromArtifact('EssentialsXChat-2.19.0-beta+5.jar')
-    ).toBe('2.19.0-beta+5');
+    expect(getVersionFromArtifact('EssentialsXChat-2.19.0-beta+5.jar')).toBe(
+      '2.19.0-beta+5',
+    );
     expect(getVersionFromArtifact('EssentialsX.jar')).toBeUndefined();
   });
 
   test('getModuleIdFromArtifact parses module id', () => {
     expect(getModuleIdFromArtifact('EssentialsX-2.19.0.jar')).toBe('core');
-    expect(getModuleIdFromArtifact('EssentialsXSpawn-2.19.0.jar')).toBe('spawn');
-    expect(getModuleIdFromArtifact('EssentialsXProtect-2.19.0.jar')).toBe('protect');
+    expect(getModuleIdFromArtifact('EssentialsXSpawn-2.19.0.jar')).toBe(
+      'spawn',
+    );
+    expect(getModuleIdFromArtifact('EssentialsXProtect-2.19.0.jar')).toBe(
+      'protect',
+    );
     expect(getModuleIdFromArtifact('RandomPlugin-1.0.jar')).toBe('core');
   });
 
   test('getCommitIdFromArtifact extracts commit id', () => {
     expect(
-      getCommitIdFromArtifact('EssentialsX-2.19.0-dev+12-abcdef.jar')
+      getCommitIdFromArtifact('EssentialsX-2.19.0-dev+12-abcdef.jar'),
     ).toBe('abcdef');
     expect(
-      getCommitIdFromArtifact('EssentialsXChat-2.19.0-rc+3-1234567.jar')
+      getCommitIdFromArtifact('EssentialsXChat-2.19.0-rc+3-1234567.jar'),
     ).toBe('1234567');
     expect(getCommitIdFromArtifact('EssentialsX-2.19.0.jar')).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- tweak commands page borders and alias ordering
- add command anchor links for easier sharing
- add search and module filtering UI
- run prettier for formatting

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68409810b61083249ae39a6ae9c329aa