### PR TITLE
Show permission sets as cards

### DIFF
--- a/app/permissions/page.tsx
+++ b/app/permissions/page.tsx
@@ -2,6 +2,7 @@
 
 import PageHeader from '@/components/page-header';
 
+import PermissionSets from '@/components/permission-sets';
 import core from '@/lib/EssentialsX-permissions.json';
 import chat from '@/lib/EssentialsXChat-permissions.json';
 import discord from '@/lib/EssentialsXDiscord-permissions.json';
@@ -194,30 +195,9 @@ export default function Permissions() {
                             </div>
                             <AnimatePresence>
                               {hasChildren && openRow === rowKey && (
-                                <motion.div
-                                  className='flex flex-col'
-                                  initial={{ height: 0, opacity: 0 }}
-                                  animate={{ height: 'auto', opacity: 1 }}
-                                  exit={{ height: 0, opacity: 0 }}
-                                  transition={{
-                                    duration: 0.2,
-                                    ease: 'easeInOut',
-                                  }}
-                                >
-                                  {children.map(([child]) => (
-                                    <div
-                                      key={child}
-                                      className='grid grid-cols-4 gap-4 p-4 pl-8 border-t border-gray-200 dark:border-gray-700 text-sm'
-                                    >
-                                      <div></div>
-                                      <div className='flex items-center prose dark:prose-invert'>
-                                        <code className='px-2 py-1 rounded text-xs'>
-                                          {child}
-                                        </code>
-                                      </div>
-                                    </div>
-                                  ))}
-                                </motion.div>
+                                <PermissionSets
+                                  permissions={children.map(([child]) => child)}
+                                />
                               )}
                             </AnimatePresence>
                           </div>

--- a/app/permissions/page.tsx
+++ b/app/permissions/page.tsx
@@ -152,14 +152,14 @@ export default function Permissions() {
                                   {mod}
                                 </Badge>
                               </div>
-                              <div className='flex items-center text-sm prose dark:prose-invert'>
+                              <div className='flex flex-col items-start text-sm prose dark:prose-invert'>
                                 <code className='px-2 py-1 rounded text-xs'>
                                   {perm}
                                 </code>
                                 {hasChildren && (
                                   <Badge
                                     variant='secondary'
-                                    className='ml-2 text-xs whitespace-nowrap'
+                                    className='mt-1 text-xs whitespace-nowrap'
                                   >
                                     Permission Group
                                   </Badge>

--- a/app/permissions/page.tsx
+++ b/app/permissions/page.tsx
@@ -168,6 +168,7 @@ export default function Permissions() {
                                   {mod}
                                 </Badge>
                               </div>
+                              <div className='prose dark:prose-invert'>
                                 <a
                                   href={`#${perm}`}
                                   className='flex items-center gap-1'
@@ -180,17 +181,14 @@ export default function Permissions() {
                                     className='text-muted-foreground'
                                   />
                                 </a>
-                                    {perm}
-                                  </code>
-                                  {hasChildren && (
-                                    <Badge
-                                      variant='secondary'
-                                      className='mt-1 text-xs whitespace-nowrap'
-                                    >
-                                      Permission Group
-                                    </Badge>
-                                  )}
-                                </div>
+                                {hasChildren && (
+                                  <Badge
+                                    variant='secondary'
+                                    className='mt-1 text-xs whitespace-nowrap'
+                                  >
+                                    Permission Group
+                                  </Badge>
+                                )}
                               </div>
                               <div className='text-sm'>
                                 {obj.description || 'None'}

--- a/app/permissions/page.tsx
+++ b/app/permissions/page.tsx
@@ -152,18 +152,20 @@ export default function Permissions() {
                                   {mod}
                                 </Badge>
                               </div>
-                              <div className='flex flex-col items-start text-sm prose dark:prose-invert'>
-                                <code className='px-2 py-1 rounded text-xs'>
-                                  {perm}
-                                </code>
-                                {hasChildren && (
-                                  <Badge
-                                    variant='secondary'
-                                    className='mt-1 text-xs whitespace-nowrap'
-                                  >
-                                    Permission Group
-                                  </Badge>
-                                )}
+                              <div className='flex items-start text-sm prose dark:prose-invert'>
+                                <div className='flex flex-col items-center gap-2'>
+                                  <code className='px-2 py-1 rounded text-xs'>
+                                    {perm}
+                                  </code>
+                                  {hasChildren && (
+                                    <Badge
+                                      variant='secondary'
+                                      className='mt-1 text-xs whitespace-nowrap'
+                                    >
+                                      Permission Group
+                                    </Badge>
+                                  )}
+                                </div>
                               </div>
                               <div className='text-sm'>
                                 {obj.description || 'None'}

--- a/app/permissions/page.tsx
+++ b/app/permissions/page.tsx
@@ -11,7 +11,7 @@ import spawn from '@/lib/EssentialsXSpawn-permissions.json';
 import xmpp from '@/lib/EssentialsXXMPP-permissions.json';
 import { Permission, PermissionData } from '@/lib/types';
 import { Badge, Button, Select, TextInput } from '@mantine/core';
-import { IconChevronDown, IconSearch } from '@tabler/icons-react';
+import { IconChevronDown, IconHash, IconSearch } from '@tabler/icons-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Fragment, useEffect, useState } from 'react';
 import { Entries } from 'type-fest';
@@ -50,6 +50,22 @@ export default function Permissions() {
   const toggleRow = (perm: string) => {
     setOpenRow(prev => (prev === perm ? '' : perm));
   };
+
+  // Scroll to anchor once permissions are loaded
+  useEffect(() => {
+    if (!loading && typeof window !== 'undefined') {
+      const id = window.location.hash.slice(1);
+      if (id) {
+        const el = document.getElementById(id);
+        if (el) {
+          const headerOffset = 80;
+          const y =
+            el.getBoundingClientRect().top + window.scrollY - headerOffset;
+          window.scrollTo({ top: y, behavior: 'smooth' });
+        }
+      }
+    }
+  }, [loading]);
 
   const formatDefault = (value: 'op' | 'noop' | boolean) => {
     switch (value) {
@@ -152,9 +168,18 @@ export default function Permissions() {
                                   {mod}
                                 </Badge>
                               </div>
-                              <div className='flex items-start text-sm prose dark:prose-invert'>
-                                <div className='flex flex-col items-center gap-2'>
+                                <a
+                                  href={`#${perm}`}
+                                  className='flex items-center gap-1'
+                                >
                                   <code className='px-2 py-1 rounded text-xs'>
+                                    {perm}
+                                  </code>
+                                  <IconHash
+                                    size={14}
+                                    className='text-muted-foreground'
+                                  />
+                                </a>
                                     {perm}
                                   </code>
                                   {hasChildren && (

--- a/components/permission-sets.tsx
+++ b/components/permission-sets.tsx
@@ -1,0 +1,67 @@
+import { motion } from 'framer-motion';
+
+export default function PermissionSets({
+  permissions,
+}: {
+  permissions: string[];
+}) {
+  return (
+    <motion.div
+      initial={{ height: 0, opacity: 0, marginBottom: 0 }}
+      animate={{
+        height: 'auto',
+        opacity: 1,
+        marginBottom: 16,
+        transition: {
+          height: { duration: 0.4, ease: 'easeInOut' },
+          opacity: { duration: 0.3, ease: 'easeInOut' },
+          marginBottom: { duration: 0.4, ease: 'easeInOut' },
+        },
+      }}
+      exit={{
+        height: 0,
+        opacity: 0,
+        marginBottom: 0,
+        transition: {
+          height: { duration: 0.3, ease: 'easeInOut' },
+          opacity: { duration: 0.2, ease: 'easeInOut' },
+          marginBottom: { duration: 0.3, ease: 'easeInOut' },
+        },
+      }}
+      className='overflow-hidden mb-10'
+      style={{ transformOrigin: 'top' }}
+    >
+      <motion.div
+        initial={{ y: -20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: -20, opacity: 0 }}
+        transition={{ duration: 0.3, delay: 0.1 }}
+        className='px-4'
+      >
+        <motion.div
+          initial={{ scale: 0.95 }}
+          animate={{ scale: 1 }}
+          transition={{ duration: 0.2, delay: 0.2 }}
+          className='prose dark:prose-invert bg-gray-100 dark:bg-[#1c1e22] rounded-lg p-4 w-full max-w-none'
+        >
+          <h4 className='font-semibold mb-3 text-sm'>Child Permissions</h4>
+          <div className='grid gap-3 sm:grid-cols-2'>
+            {permissions.map((perm, idx) => (
+              <motion.div
+                key={perm}
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3, delay: 0.2 + idx * 0.1 }}
+                className='prose dark:prose-invert'
+              >
+                <code className='text-xs bg-background px-2 py-1 rounded block transition-colors duration-200'>
+                  {perm}
+                </code>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/components/permission-sets.tsx
+++ b/components/permission-sets.tsx
@@ -54,7 +54,7 @@ export default function PermissionSets({
                 transition={{ duration: 0.3, delay: 0.2 + idx * 0.1 }}
                 className='prose dark:prose-invert'
               >
-                <code className='text-xs bg-background px-2 py-1 rounded block transition-colors duration-200'>
+                <code className='text-xs bg-background px-2 py-1 rounded inline-block w-fit transition-colors duration-200'>
                   {perm}
                 </code>
               </motion.div>


### PR DESCRIPTION
## Summary
- add component `PermissionSets` to display child permissions with card styling
- import and use `PermissionSets` on permissions page

## Testing
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68448f5203c0832499d1a178b21f2e3a