### PR TITLE
Remove right chevron in commands page

### DIFF
--- a/app/commands/page.tsx
+++ b/app/commands/page.tsx
@@ -9,7 +9,6 @@ import { Command, CommandData } from '@/lib/types';
 import { Badge, Button, Select, TextInput } from '@mantine/core';
 import {
   IconChevronDown,
-  IconChevronRight,
   IconHash,
   IconSearch,
 } from '@tabler/icons-react';
@@ -183,9 +182,6 @@ export default function Commands() {
                                     <code className='rounded px-1 py-0.5 text-xs'>
                                       {sortedAliases[0]}
                                     </code>
-                                    <div className='flex items-center justify-center py-1'>
-                                      <IconChevronRight className='h-4 w-4 stroke-red-300' />
-                                    </div>
                                     {sortedAliases.length > 1 && (
                                       <span className='text-xs'>
                                         +{sortedAliases.length - 1} more


### PR DESCRIPTION
Makes it seem like there's a button (since other chevrons are used as such) when there isn't one