### PR TITLE
ci: run bun lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run lint
+        run: bun lint
+      - name: Fail if lint made changes
+        run: git diff --exit-code


### PR DESCRIPTION
## Summary
- replace Node-based lint workflow with Bun
- fail CI when `bun lint` modifies files
- revert accidental formatting changes in `app/globals.css` and `wrangler.jsonc`

## Testing
- `bun lint`
- `git diff --exit-code`


------
https://chatgpt.com/codex/tasks/task_e_689219357b2c83248c9fa26aa2a14ccc