### PR TITLE
fix: update download page to use stable builds

### DIFF
--- a/components/download-selector.tsx
+++ b/components/download-selector.tsx
@@ -18,7 +18,7 @@ const ZIP_SMITH_WORKER = 'https://zip-smith.essentialsx.workers.dev';
 
 export default function DownloadSelector() {
   const params = useSearchParams();
-  const startBranch = params.get('branch') || 'dev';
+  const startBranch = 'stable';
   const [selectedModules, setSelectedModules] = useState<string[]>(['core']);
   const [buildType, setBuildType] = useState(startBranch);
   const [isDownloading, setIsDownloading] = useState(false);


### PR DESCRIPTION
# Description
Changes the download page from unstable developer build downloads to tested, stable builds. This helps because developer builds have not been tested (if not, very little), and stable builds have been thoroughly tested.

# Related Issues
Does not fix any issues.

# Test Steps
I used `npm install` and `npm run dev` after making my changes to ensure that the website works locally. No errors occurred on my end.